### PR TITLE
Fix preset selection warning when user loads a graph.

### DIFF
--- a/Foreman/DataCache/PresetProcessor.cs
+++ b/Foreman/DataCache/PresetProcessor.cs
@@ -251,7 +251,7 @@ namespace Foreman
 			}
 
 			//have to process mining, generators and boilers (since we convert them to recipes as well)
-			foreach (var objJToken in jsonData["resources"])
+			foreach (var objJToken in jsonData["resources"].Concat(jsonData["water_resources"]))
 			{
 				if (objJToken["products"].Count() == 0)
 					continue;


### PR DESCRIPTION
When a user loads a graph, Foreman would look for matching presets but fail to find a match because it did not load in the `water_resources` which resulted in it failing to notice things like water.

We now do this by concatenating it onto the `resources` enumerable.

Fixes #108