### PR TITLE
Fix uncaught exception when sorting columns in Graph Summary

### DIFF
--- a/Foreman/Forms/GraphSummaryForm.cs
+++ b/Foreman/Forms/GraphSummaryForm.cs
@@ -537,10 +537,15 @@ namespace Foreman
 				else
 					result = -((double)a.SubItems[column].Tag).CompareTo((double)b.SubItems[column].Tag);
 
-				if (result == 0)
-					result = ((DataObjectBase)a.Tag).LFriendlyName.CompareTo(((DataObjectBase)b.Tag).LFriendlyName);
-				if (result == 0)
-					result = ((DataObjectBase)a.Tag).Name.CompareTo(((DataObjectBase)b.Tag).Name);
+				if (result == 0 && a.Tag is DataObjectBase ado && b.Tag is DataObjectBase bdo) {
+					result = ado.LFriendlyName.CompareTo(bdo.LFriendlyName);
+					if (result == 0)
+						result = ado.Name.CompareTo(bdo.Name);
+				}
+
+				if (result == 0 && a.Tag is ItemQualityPair aqp && b.Tag is ItemQualityPair bqp && aqp.Quality != null)
+					result = aqp.Quality.Level.CompareTo(bqp.Quality.Level);
+
 				return result * reverseSortLamda;
 			});
 


### PR DESCRIPTION
The callback responsible for sorting columns would assume that the Tag field of the control always held a `DataObjectBase` but this is not necessarily true.

We now safely check if the type is compatible to avoid an uncaught exception.

Additionally, I have added code that will make a final attempt to sort by quality level; though I'm not entirely clear if it actually makes sense to do so here. If not, please let me know and I can alter/remove it.

fixes #106